### PR TITLE
chore(go): Bump Go version from 1.13 to 1.16

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: 1.16
 
       # build image
       - name: Docker Build
@@ -34,7 +34,7 @@ jobs:
               --tag $ECR_REGISTRY/muss:$GITHUB_SHA \
               --tag $ECR_REGISTRY/muss:latest \
               .
-      
+
       # build and test golang
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.13
+        go-version: 1.16
     # Release the thing!
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
@@ -24,4 +24,3 @@ jobs:
         args: release
       env:
         GITHUB_TOKEN: ${{ secrets.INSTRUCTURE_BRIDGE_GITHUB_BOT_REPO_RW }}
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine
+FROM golang:1.16-alpine3.13
 
 RUN apk --no-cache add \
     bash \

--- a/cmd/config/show_test.go
+++ b/cmd/config/show_test.go
@@ -189,7 +189,7 @@ func TestConfigShow(t *testing.T) {
 
 		assert.Contains(t,
 			stderr,
-			`unexpected unclosed action in command`,
+			`unclosed action`,
 			"error on stderr",
 		)
 

--- a/config/secrets_test.go
+++ b/config/secrets_test.go
@@ -402,7 +402,7 @@ func TestSecretCommands(t *testing.T) {
 		cfg.SecretCommands["some"].Cache = "foo"
 
 		assert.Equal(t,
-			`time: invalid duration foo`,
+			`time: invalid duration "foo"`,
 			testSecretError(t, cfg, secretSpec))
 
 		cfg.SecretCommands["some"].Cache = "none"


### PR DESCRIPTION
We're updating Go to version 1.16 so that `muss` builds are available to
Mac M1 (Apple Silicon; arm64) machines. (This functionality comes from
GoReleaser, which added support for the M1 architecture beginning with
Go 1.16)