### PR TITLE
Chore: bump alpine base image to latest

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.16-alpine
 
 RUN apk --no-cache add \
     bash \


### PR DESCRIPTION
Include .dockerignore to exclude `coverage/` from getting added
to the docker image during development.