### PR TITLE
Replace outdated Instructure references

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Instructure, Inc.
+Copyright (c) 2021 Bridge
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/instructure/muss.svg?branch=master)](https://travis-ci.org/instructure/muss)
+[![Build Status](https://travis-ci.org/get-bridge/muss.svg?branch=master)](https://travis-ci.org/get-bridge/muss)
 
 # muss
 
@@ -29,7 +29,7 @@ in a familiar style through a series of yaml files.
 
 # Installation
 
-    brew tap instructure/muss
+    brew tap get-bridge/muss
     brew install muss
 
 


### PR DESCRIPTION
This housecleaning PR seeks to replace references to Instructure that are outdated now that this repo has migrated ownership to Bridge. This PR is mostly a documentation change, though there are a couple of things that deserve further discussion:

### Renaming secrets

We have a secret with the following key: `INSTRUCTURE_BRIDGE_GITHUB_BOT_REPO_RW`. Since this PR is focused on removing references to Instructure, we should also rename this secret as `BRIDGE_GITHUB_BOT_REPO_RW`. I haven't made this change because I noticed that the secret is an Organization secret, so someone with access to org secrets will have to make that change. 

_Side note:_ there are several other org secrets that refer to Instructure, though some of them may still be linked to Instructure. That's out of the scope of this PR but worth mentioning.

### Travis CI Integration

I've updated the Travis CI badge that linked to this repo's page on Travis CI. However, `muss`' presence on Travis CI is quite stale, with no new activity in the past ten months. I don't have credentials for Travis CI within Bridge, so I can't make any progress on this front. 